### PR TITLE
Add support for recording profiles using pyinstrument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
         "opentelemetry-exporter-otlp",
         "opentelemetry-instrumentation-wsgi",
     ],
+    extras_require={
+        "profiler": ["pyinstrument"],
+    },
     entry_points="""
     [z3c.autoinclude.plugin]
     target = plone

--- a/src/collective/opentelemetry/middleware.py
+++ b/src/collective/opentelemetry/middleware.py
@@ -3,6 +3,11 @@ from opentelemetry.trace import Span
 from .interfaces import SPAN_KEY
 from .patches import apply_patches
 
+try:
+    from .profiler import profiler_middleware_factory
+except ImportError:
+    profiler_middleware_factory = None
+
 
 def request_hook(span: Span, environ: dict):
     # Store a reference to the span so it can be used from ZPublisher events
@@ -13,6 +18,9 @@ def wsgi_middleware_factory(global_config):
     apply_patches()
 
     def filter(app):
+        # Only add profiler middleware if pyinstrument is installed
+        if profiler_middleware_factory is not None:
+            app = profiler_middleware_factory(app)
         return OpenTelemetryMiddleware(app, request_hook=request_hook)
 
     return filter

--- a/src/collective/opentelemetry/profiler.py
+++ b/src/collective/opentelemetry/profiler.py
@@ -1,0 +1,28 @@
+from .interfaces import SPAN_KEY
+from pyinstrument import Profiler
+import re
+
+
+PROFILE_COOKIE_RE = re.compile(r"(^|;)\s*profile=1(;|$)")
+
+
+def profiler_middleware_factory(app):
+    def profiler_middleware(environ, start_response):
+        # check if enabled (by setting the cookie profile=1)
+        cookie = environ.get("HTTP_COOKIE") or ""
+        enabled = PROFILE_COOKIE_RE.search(cookie)
+
+        # if not enabled, just run the app
+        if not enabled:
+            return app(environ, start_response)
+
+        # run the app with the profiler
+        with Profiler() as profiler:
+            result = app(environ, start_response)
+
+        # add profile event to opentelemetry span
+        span = environ[SPAN_KEY]
+        span.add_event("profile", attributes={"profile.text": profiler.output_text(show_all=True)})
+
+        return result
+    return profiler_middleware


### PR DESCRIPTION
Enabled by setting the cookie `profile=1` -- we can go for something more secure if needed, but at least the profile is not exposed anywhere except via the opentelemetry instrumentation, and it is a statistical profiler which should not have a large impact on performance